### PR TITLE
alias assert as expect

### DIFF
--- a/lib/tiramisu/assert.rb
+++ b/lib/tiramisu/assert.rb
@@ -1,10 +1,17 @@
 module Tiramisu
   class Assert
-    EXCEPTIONAL_ASSERTIONS = {
+    BUNDLED_ASSERTIONS = {
       :raises  => true,
       'raises' => true,
+      
+      :to_raise  => true,
+      'to_raise' => true,
+      
       :throws  => true,
-      'throws' => true
+      'throws' => true,
+      
+      :to_throw  => true,
+      'to_throw' => true
     }.freeze
 
     def initialize object, action = :assert, block = nil, caller = nil
@@ -40,7 +47,7 @@ module Tiramisu
 
     private
     def __assert__ message, arguments, block
-      object = if EXCEPTIONAL_ASSERTIONS[message]
+      object = if BUNDLED_ASSERTIONS[message]
         @block || raise(ArgumentError, '%s expects a block' % message)
       else
         @block ? @block.call : @object

--- a/lib/tiramisu/assertions/raises.rb
+++ b/lib/tiramisu/assertions/raises.rb
@@ -1,4 +1,4 @@
-assert :raises do |proc, type, message, &block|
+assert :raises, :to_raise do |proc, type, message, &block|
   Tiramisu.raised_as_expected?(proc, type, message, block)
   true # if arriving here without failing the assertion is passed
 end

--- a/lib/tiramisu/assertions/throws.rb
+++ b/lib/tiramisu/assertions/throws.rb
@@ -1,4 +1,4 @@
-assert :throws do |proc, expected_symbol, expected_value|
+assert :throws, :to_throw do |proc, expected_symbol, expected_value|
   thrown_symbol, thrown_value = Tiramisu.catch_symbol(proc, expected_symbol)
   if expected_symbol
     unless expected_symbol == thrown_symbol

--- a/lib/tiramisu/unit.rb
+++ b/lib/tiramisu/unit.rb
@@ -12,6 +12,7 @@ module Tiramisu
         Tiramisu::Assert.new(obj, meth, block, caller[0])
       end
     end
+    alias expect assert
 
     # stop executing current test and mark it as skipped
     #


### PR DESCRIPTION
Feeling much better to type `expect(x).to_raise(y)` instead of `assert(x).raises(y)`
